### PR TITLE
Remove unused orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  codecov: codecov/codecov@1.0.5
-
 jobs:
   build:
     docker:


### PR DESCRIPTION
`codecov/codecov@1.0.5` is not used.