### PR TITLE
Support multiple upstream options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/build/
+/bin/
 
 # Created by https://www.gitignore.io/api/go
 # Edit at https://www.gitignore.io/?templates=go

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,0 @@
-{
-  "singleQuote": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,16 @@
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "[markdown]": {
+    "editor.wordWrap": "on",
+    "editor.quickSuggestions": false,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
+    "editor.quickSuggestions": {
+      "other": true,
+      "comments": false,
+      "strings": true
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
-FROM golang:1.12 AS build
+FROM golang:1.13 AS build
 
 COPY . /app
 WORKDIR /app
 
-RUN make
+ARG VERSION=0.0.0
+RUN make VERSION=${VERSION}
 
-FROM scratch
+FROM alpine:3.9
 
-COPY --from=build \
-  /app/build/takanawa \
-  /usr/local/bin/takanawa
+COPY --from=build /app/bin/* /usr/local/bin/
 
 EXPOSE 5000
 ENV HOST=0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,15 @@
 NAME		:= takanawa
 VERSION		:= 0.0.0
+OUTPUT		:= bin
 
 GOOS		:= $(shell go env GOOS)
 GOARCH		:= $(shell go env GOARCH)
 
-TARGET		:= build/$(NAME)
 LDFLAGS		:= -w -X main.version=$(VERSION)
 EXTLDFLAGS	:=
 TAGS		:=
 
 ifeq ($(GOOS),windows)
-TARGET		:= $(TARGET).exe
 LDFLAGS		:= $(LDFLAGS) -H=windowsgui
 EXTLDFLAGS	:= $(EXTLDFLAGS) -static
 endif
@@ -37,8 +36,8 @@ GO.test		:= go test -v -cover -coverprofile=coverage.out -covermode=atomic
 default: build
 
 .PHONY: build
-build:
-	$(GO.build) -o $(TARGET) ./cmd/$(NAME)
+build: $(OUTPUT)
+	$(GO.build) -o $(OUTPUT) ./...
 
 .PHONY: test
 test:
@@ -46,4 +45,7 @@ test:
 
 .PHONY: clean
 clean:
-	$(RM) $(TARGET)
+	$(RM) $(wildcard $(OUTPUT)/*)
+
+$(OUTPUT):
+	mkdir -p $@

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ For example, execute the following command to proxy `/` to UI server
 and `/api` to the API server:
 
 ```shell
-$ takanawa /api:http://localhost:8080/v1 http://localhost:3000
+$ takanawa --access-log=common \
+    http://localhost:3000 --change-origin \
+    http://localhost:8080/v1 --change-origin --path=/api
 ```
 
 Takanawa runs on port 5000 by default.
@@ -19,3 +21,17 @@ Takanawa runs on port 5000 by default.
 ## Requirements
 
 - Go 1.11+
+
+## Installation
+
+```shell
+$ go get -u github.com/kou64yama/takanawa
+```
+
+## Docker
+
+```shell
+$ docker run -p 5000:5000 kou64yama/takanawa --access-log=common \
+    http://localhost:3000 --change-origin \
+    http://localhost:8080/v1 --change-origin --path=/api
+```

--- a/internal/mock/handler.go
+++ b/internal/mock/handler.go
@@ -2,6 +2,7 @@ package mock
 
 import "net/http"
 
+// The Handler is the mock of http.Handler.
 type Handler struct {
 	http.Handler
 	MockServeHTTP   func(w http.ResponseWriter, r *http.Request)

--- a/internal/mock/response_writer.go
+++ b/internal/mock/response_writer.go
@@ -2,6 +2,7 @@ package mock
 
 import "net/http"
 
+// The ResponseWriter is the mock of http.ResponseWriter
 type ResponseWriter struct {
 	http.ResponseWriter
 	MockHeader        func() http.Header
@@ -12,6 +13,7 @@ type ResponseWriter struct {
 	CalledWriteHeader [][]interface{}
 }
 
+// Header calls MockHeader.
 func (w *ResponseWriter) Header() http.Header {
 	w.CalledHeader = append(w.CalledHeader, []interface{}{})
 	if w.MockHeader != nil {
@@ -28,6 +30,7 @@ func (w *ResponseWriter) Write(b []byte) (int, error) {
 	return 0, nil
 }
 
+// WriteHeader calls MockWriteHeader.
 func (w *ResponseWriter) WriteHeader(statusCode int) {
 	w.CalledWriteHeader = append(w.CalledWriteHeader, []interface{}{statusCode})
 	if w.MockWriteHeader != nil {

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -1,11 +1,10 @@
 package util
 
 import (
-	"fmt"
 	"net/http"
-	"strings"
 )
 
+// The ResponseSniffer sniff http.ResponseWriter methods.
 type ResponseSniffer struct {
 	http.ResponseWriter
 	Writer     http.ResponseWriter
@@ -13,6 +12,7 @@ type ResponseSniffer struct {
 	Length     uint64
 }
 
+// Header calls w.Writer.Header()
 func (w *ResponseSniffer) Header() http.Header {
 	return w.Writer.Header()
 }
@@ -23,24 +23,8 @@ func (w *ResponseSniffer) Write(b []byte) (int, error) {
 	return size, err
 }
 
+// WriteHeader calls w.Writer.WriteHeader(statusCode) and saves statusCode.
 func (w *ResponseSniffer) WriteHeader(statusCode int) {
 	w.Writer.WriteHeader(statusCode)
 	w.StatusCode = statusCode
-}
-
-func FormatRequest(req *http.Request) string {
-	s := fmt.Sprintln(req.Method, req.RequestURI, req.Proto)
-	s += fmt.Sprintln("Host:", req.Host)
-	for n, v := range req.Header {
-		s += fmt.Sprintf("%s: %s\n", n, strings.Join(v, "; "))
-	}
-	return s
-}
-
-func FormatResponse(resp *http.Response) string {
-	s := fmt.Sprintln(resp.Proto, resp.StatusCode)
-	for n, v := range resp.Header {
-		s += fmt.Sprintf("%s: %s\n", n, strings.Join(v, "; "))
-	}
-	return s
 }

--- a/internal/util/net.go
+++ b/internal/util/net.go
@@ -6,9 +6,11 @@ import (
 )
 
 var (
+	// ErrNoIP is returned on FindIP cannot find net.IP.
 	ErrNoIP = errors.New("No IP addess")
 )
 
+// FindIP finds the net.IP in net.InterfaceAddrs().
 func FindIP(p func(net.IP) bool) (net.IP, error) {
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {

--- a/internal/util/url.go
+++ b/internal/util/url.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"net/url"
+	"regexp"
+)
+
+// MustURL parses rawurl into a URL structure.
+//
+// This panics if the error occurs.
+func MustURL(rawurl string) *url.URL {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		panic(err)
+	}
+	regexp.MustCompile("")
+	return u
+}

--- a/middleware/change_origin.go
+++ b/middleware/change_origin.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/kou64yama/takanawa"
+)
+
+// ChangeOrigin changes the Host request header.
+func ChangeOrigin(host string) takanawa.Middleware {
+	return takanawa.MiddlewareFunc(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r2 := &http.Request{}
+			*r2 = *r
+			r2.Host = host
+			next.ServeHTTP(w, r2)
+		})
+	})
+}

--- a/middleware/change_origin_test.go
+++ b/middleware/change_origin_test.go
@@ -1,0 +1,27 @@
+package middleware_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/kou64yama/takanawa/internal/mock"
+	"github.com/kou64yama/takanawa/middleware"
+)
+
+func TestChangeOrigin(t *testing.T) {
+	t.Helper()
+
+	h := &mock.Handler{}
+	w := &mock.ResponseWriter{}
+	r := &http.Request{Host: "localhost"}
+	middleware.ChangeOrigin("example.com").Apply(h).ServeHTTP(w, r)
+
+	if len(h.CalledServeHTTP) == 0 {
+		t.Error("handler not called, want called")
+		return
+	}
+	req := h.CalledServeHTTP[0][1].(*http.Request)
+	if req.Host != "example.com" {
+		t.Errorf("got %s, want %s", req.Host, "example.com")
+	}
+}

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -7,8 +7,9 @@ import (
 	"github.com/kou64yama/takanawa"
 )
 
+// CorsOption is options of Cors.
 type CorsOption struct {
-	takanawa.Middleware
+	takanawa.MiddlewareFunc
 	AllowedOrigins   []string
 	AllowedMethods   []string
 	AllowedHeaders   []string
@@ -16,11 +17,12 @@ type CorsOption struct {
 	AllowCredentials bool
 }
 
+// Cors returns the middleware.
 func Cors(opt *CorsOption) takanawa.Middleware {
 	if opt == nil {
 		opt = &CorsOption{}
 	}
-	return func(next http.Handler) http.Handler {
+	return takanawa.MiddlewareFunc(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			h := w.Header()
 			for _, v := range opt.AllowedOrigins {
@@ -44,5 +46,5 @@ func Cors(opt *CorsOption) takanawa.Middleware {
 
 			next.ServeHTTP(w, r)
 		})
-	}
+	})
 }

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -98,7 +98,7 @@ func TestCors(t *testing.T) {
 				Host: tt.host,
 			}
 			n := &mock.Handler{}
-			middleware.Cors(tt.option)(n).ServeHTTP(w, r)
+			middleware.Cors(tt.option).Apply(n).ServeHTTP(w, r)
 
 			accessControlAllowOrigin := header.Get(takanawa.HeaderAccessControlAllowOrigin)
 			if accessControlAllowOrigin != tt.accessControlAllowOrigin {

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,0 +1,2 @@
+// Package middleware is the middlewares of takanawa.
+package middleware

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -8,8 +8,9 @@ import (
 	"github.com/kou64yama/takanawa"
 )
 
+// RequestID returns the middleware.
 func RequestID() takanawa.Middleware {
-	return func(next http.Handler) http.Handler {
+	return takanawa.MiddlewareFunc(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			id := r.Header.Get(takanawa.HeaderTakanawaRequestID)
 			if len(id) == 0 {
@@ -23,5 +24,5 @@ func RequestID() takanawa.Middleware {
 			ctx = context.WithValue(ctx, takanawa.ContextTakanawaRequestID, id)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
-	}
+	})
 }

--- a/middleware/request_id_test.go
+++ b/middleware/request_id_test.go
@@ -21,7 +21,7 @@ func TestRequestID(t *testing.T) {
 		r := &http.Request{
 			Header: reqHeader,
 		}
-		middleware.RequestID()(&mock.Handler{}).ServeHTTP(w, r)
+		middleware.RequestID().Apply(&mock.Handler{}).ServeHTTP(w, r)
 
 		id := resHeader.Get(takanawa.HeaderTakanawaRequestID)
 		if len(id) == 0 {
@@ -40,7 +40,7 @@ func TestRequestID(t *testing.T) {
 		r := &http.Request{
 			Header: reqHeader,
 		}
-		middleware.RequestID()(&mock.Handler{}).ServeHTTP(w, r)
+		middleware.RequestID().Apply(&mock.Handler{}).ServeHTTP(w, r)
 
 		id := resHeader.Get(takanawa.HeaderTakanawaRequestID)
 		if id != "e0968622-a057-46e1-95bd-49380695b639" {

--- a/middleware/reverse_proxy.go
+++ b/middleware/reverse_proxy.go
@@ -1,79 +1,18 @@
 package middleware
 
 import (
-	"errors"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strings"
 
 	"github.com/kou64yama/takanawa"
 )
 
-type ReverseProxyOption struct {
-	Path          string
-	OverwriteHost bool
-	RewritePath   func(string) string
-	ErrorLog      *log.Logger
-}
-
-func ParseReverseProxyOption(s string) (*url.URL, *ReverseProxyOption, error) {
-	path := ""
-	if strings.HasPrefix(s, "/") {
-		sp := strings.SplitN(s, ":", 2)
-		if len(sp) != 2 {
-			return nil, nil, errors.New("malformed: " + s)
-		}
-		path = sp[0]
-		s = sp[1]
-	}
-
-	u, err := url.Parse(s)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	o := &ReverseProxyOption{}
-	o.Path = path
-	o.RewritePath = func(p string) string { return p[len(path):] }
-
-	return u, o, nil
-}
-
-func ReverseProxy(target *url.URL, opt *ReverseProxyOption) takanawa.Middleware {
-	if opt == nil {
-		opt = &ReverseProxyOption{}
-	}
-
+// ReverseProxy returns the middleware that invokes httputil.ReverseProxy.
+func ReverseProxy(target *url.URL) takanawa.Middleware {
 	p := httputil.NewSingleHostReverseProxy(target)
-	p.ErrorLog = opt.ErrorLog
-
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r1 *http.Request) {
-			if !strings.HasPrefix(r1.URL.Path, opt.Path) {
-				next.ServeHTTP(w, r1)
-				return
-			}
-
-			r2 := &http.Request{}
-			*r2 = *r1
-
-			if opt.OverwriteHost {
-				r2.Host = target.Host
-			}
-
-			if opt.RewritePath != nil {
-				*r2.URL = *r1.URL
-				r2.URL.Path = opt.RewritePath(r1.URL.Path)
-			}
-
-			id, ok := r1.Context().Value(takanawa.ContextTakanawaRequestID).(string)
-			if ok {
-				r2.Header.Set(takanawa.HeaderTakanawaRequestID, id)
-			}
-
-			p.ServeHTTP(w, r2)
-		})
-	}
+	p.ErrorLog = log.New(ioutil.Discard, "", 0)
+	return takanawa.MiddlewareFunc(func(http.Handler) http.Handler { return p })
 }

--- a/middleware/reverse_proxy_test.go
+++ b/middleware/reverse_proxy_test.go
@@ -1,108 +1,51 @@
 package middleware_test
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"testing"
 
+	"github.com/kou64yama/takanawa/internal/mock"
+	"github.com/kou64yama/takanawa/internal/util"
 	"github.com/kou64yama/takanawa/middleware"
 )
 
-func TestParseReverseProxyOption(t *testing.T) {
-	success := []struct {
-		in   string
-		url  string
-		path string
-	}{
-		{in: "http://localhost:3000", url: "http://localhost:3000", path: ""},
-		{in: "/api:http://localhost:8080/v1", url: "http://localhost:8080/v1", path: "/api"},
-	}
-	failure := []string{
-		"/api",
-		"http://localhost:3000\t",
-	}
-
-	for _, tt := range success {
-		t.Run(tt.in, func(t *testing.T) {
-			t.Helper()
-
-			u, opt, _ := middleware.ParseReverseProxyOption(tt.in)
-			if u.String() != tt.url {
-				t.Errorf("got %q, want %q", u, tt.url)
-			}
-			if opt.Path != tt.path {
-				t.Errorf("got %q, want %q", opt.Path, tt.path)
-			}
-		})
-	}
-	for _, tt := range failure {
-		t.Run(tt, func(t *testing.T) {
-			t.Helper()
-
-			_, _, err := middleware.ParseReverseProxyOption(tt)
-			if err == nil {
-				t.Error("got nil, want not nil")
-			}
-		})
-	}
-}
-
 func TestReverseProxy(t *testing.T) {
-	tests := []struct {
-		proxy           string
-		requestURI      string
-		proxyRequestURI string
-	}{
-		{
-			proxy:           "http://%s",
-			requestURI:      "/",
-			proxyRequestURI: "/",
-		},
-		{
-			proxy:           "/api:http://%s/v1",
-			requestURI:      "/api/message",
-			proxyRequestURI: "/v1/message",
-		},
-		{
-			proxy:           "/api:http://%s/v1",
-			requestURI:      "/",
-			proxyRequestURI: "",
-		},
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer ln.Close()
+
+	srv := http.Server{}
+	defer srv.Close()
+	closeIdleConnections := make(chan struct{}, 1)
+	go func() {
+		t.Logf("Listen on %s", ln.Addr())
+		if err := srv.Serve(ln); err != http.ErrServerClosed {
+			t.Error(err)
+		}
+		t.Log("Closed")
+		close(closeIdleConnections)
+	}()
+
+	h := &mock.Handler{}
+	w := &mock.ResponseWriter{
+		MockHeader: func() http.Header { return http.Header{} },
+	}
+	r := &http.Request{
+		Method: http.MethodGet,
+		URL:    util.MustURL("/"),
+		Header: http.Header{},
+	}
+	middleware.ReverseProxy(util.MustURL("http://"+ln.Addr().String())).Apply(h).ServeHTTP(w, r)
+	if len(w.CalledWriteHeader) != 1 {
+		t.Errorf("called %d, want 1", len(w.CalledWriteHeader))
 	}
 
-	for _, tt := range tests {
-		n := fmt.Sprintf("proxy=%s,requestURI=%s", tt.proxy, tt.requestURI)
-		t.Run(n, func(t *testing.T) {
-			t.Helper()
-
-			upLn, _ := net.Listen("tcp", "127.0.0.1:0")
-			defer upLn.Close()
-			proxyLn, _ := net.Listen("tcp", "127.0.0.1:0")
-			defer proxyLn.Close()
-
-			var proxyRequestURI string
-			up := &http.Server{
-				Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-					w.WriteHeader(200)
-					proxyRequestURI = req.RequestURI
-				}),
-			}
-			defer up.Close()
-
-			u, opt, _ := middleware.ParseReverseProxyOption(fmt.Sprintf(tt.proxy, upLn.Addr()))
-			mid := middleware.ReverseProxy(u, opt)
-			proxy := &http.Server{Handler: mid(http.NotFoundHandler())}
-			defer proxy.Close()
-
-			go up.Serve(upLn)
-			go proxy.Serve(proxyLn)
-
-			http.Get("http://" + proxyLn.Addr().String() + tt.requestURI)
-
-			if proxyRequestURI != tt.proxyRequestURI {
-				t.Errorf("got %q, want %q", proxyRequestURI, tt.proxyRequestURI)
-			}
-		})
-	}
+	srv.Close()
+	<-closeIdleConnections
 }

--- a/middleware/strip_prefix.go
+++ b/middleware/strip_prefix.go
@@ -1,0 +1,14 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/kou64yama/takanawa"
+)
+
+// StripPrefix returns a middleware that invokes http.StripPrefix(prefix, handler).
+func StripPrefix(prefix string) takanawa.Middleware {
+	return takanawa.MiddlewareFunc(func(next http.Handler) http.Handler {
+		return http.StripPrefix(prefix, next)
+	})
+}

--- a/middleware/strip_prefix_test.go
+++ b/middleware/strip_prefix_test.go
@@ -1,0 +1,61 @@
+package middleware_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/kou64yama/takanawa/internal/mock"
+	"github.com/kou64yama/takanawa/internal/util"
+	"github.com/kou64yama/takanawa/middleware"
+)
+
+func TestStripPrefix(t *testing.T) {
+	tests := []struct {
+		prefix  string
+		request *url.URL
+		called  *url.URL
+	}{
+		{
+			prefix:  "/api/v1",
+			request: util.MustURL("/api/v1/path/to/resource"),
+			called:  util.MustURL("/path/to/resource"),
+		},
+		{
+			prefix:  "/api/v1",
+			request: util.MustURL("/path/to/resource"),
+		},
+	}
+	for _, tt := range tests {
+		n := fmt.Sprintf("prefix=%q, before=%q, after=%q", tt.prefix, tt.request, tt.called)
+		t.Run(n, func(t *testing.T) {
+			t.Helper()
+
+			h := &mock.Handler{}
+			w := &mock.ResponseWriter{
+				MockHeader: func() http.Header { return http.Header{} },
+			}
+			r := &http.Request{
+				Method: http.MethodGet,
+				URL:    tt.request,
+				Header: http.Header{},
+			}
+			middleware.StripPrefix(tt.prefix).Apply(h).ServeHTTP(w, r)
+
+			if tt.called != nil {
+				if len(h.CalledServeHTTP) != 1 {
+					t.Errorf("called %d, want 1", len(h.CalledServeHTTP))
+				}
+				req := h.CalledServeHTTP[0][1].(*http.Request)
+				if req.URL.String() != tt.called.String() {
+					t.Errorf("got %s, want %s", req.URL, tt.called)
+				}
+			} else {
+				if len(h.CalledServeHTTP) > 0 {
+					t.Errorf("called %d, want 0", len(h.CalledServeHTTP))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Enabled to specify options for each upstream.

```
takanawa [global_options] \
  <upstream> [upstream_options] \
  [<upstream> [upstream_options]]...
```

For example, to rewrite the Host header only for the proxy http://localhost:3000, do as follows.

```
takanawa --access-log=common \
    http://localhost:3000 --change-origin \
    http://localhost:8080/v1 --path=/api
```